### PR TITLE
Fixed array to string conversion in CheckboxList::isFilled()

### DIFF
--- a/src/CheckboxList.php
+++ b/src/CheckboxList.php
@@ -265,6 +265,18 @@ class CheckboxList extends BaseControl
 
 
 	/**
+	 * Is control filled?
+	 * @return bool
+	 */
+	public function isFilled()
+	{
+		$value = $this->getValue();
+		return is_array($value) ? count($value) > 0 : $value !== NULL;
+	}
+
+
+
+	/**
 	 * Validator for the maximum amount of checked boxes
 	 *
 	 * @param  CheckboxList


### PR DESCRIPTION
BaseControl::isFilled() is using string cast for comparison, thus it fails on 5.4+ on array to string conversion (but I wonder if it ever worked on 5.3).
